### PR TITLE
Bug/issue loading existing database

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
@@ -49,8 +49,9 @@ namespace Stratis.Bitcoin.Features.Consensus
 
         public async Task LoadAsync()
         {
-            uint256 hash = await this.dBreezeCoinView.GetTipHashAsync().ConfigureAwait(false);
-            ChainedHeader next = this.chain.GetBlock(hash);
+            /// TODO temp fix for now as per Sondreb code; perm fix needed
+			//uint256 hash = await this.dBreezeCoinView.GetTipHashAsync().ConfigureAwait(false);
+            ChainedHeader next = this.chain.Tip; // this.chain.GetBlock(hash);
             var load = new List<StakeItem>();
 
             while (next != this.chain.Genesis)


### PR DESCRIPTION
* Bug: Fix problem with null reference exception on database load

- Uses the available tip, as oppose to coinview, which sometimes returns hash not found in the ConcurrentChain.

Source: https://github.com/CityChainFoundation/city-chain/commit/691ab2b85d9ec6a170a80193b84d631eb09cd872